### PR TITLE
Re-add Ghost key into gatsby config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -17,7 +17,6 @@ module.exports = {
     description: 'A developer community for everyone',
     siteUrl: 'https://www.byteconf.com',
   },
-  // pathPrefix: '/gatsby-starter-blog',
   plugins: [
     `gatsby-plugin-sass`,
     {
@@ -25,7 +24,7 @@ module.exports = {
       options: {
         apiUrl: `https://blog.byteconf.com`,
         clientId: `ghost-frontend`,
-        clientSecret: process.env.GHOST_SECRET,
+        clientSecret: `a9581dc692c6`,
       },
     },
     {


### PR DESCRIPTION
This allows people to contribute to the project! I had to confirm that there were no mutations exposed by our Sanity or Ghost APIs - all this data is read-only